### PR TITLE
fix: fix empty schema error.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,7 @@ dependencies = [
  "prost",
  "serde",
  "serde_derive",
+ "serde_json",
  "serde_yaml",
  "stdng",
  "strum",

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -17,6 +17,7 @@ log = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tonic = { workspace = true }
+serde_json = { workspace = true }
 
 tokio-stream = "0.1"
 thiserror = "1.0"


### PR DESCRIPTION
When `application.schema` is `None`, we will get the following error. The PR fix to by avoid `Json(None)` in sqlx.

```
Error: Storage("failed to register application <empty-app>: 'failed to execute SQL: error occurred while decoding column \"schema\": invalid type: null, expected struct AppSchemaDao at line 1 column 4'")
```